### PR TITLE
Add react hooks rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
   extends: './index.js',
-}
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
     jest: true,
     browser: true,
   },
-  plugins: ['jest'],
+  plugins: ['jest', 'react-hooks'],
   globals: {
     _: false,
     I18n: false,
@@ -41,6 +41,8 @@ module.exports = {
     'react/no-danger': 0,
     'react/no-children-prop': 0,
     'react/no-string-refs': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'error',
     'react/prefer-stateless-function': [
       0,
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lessonly/eslint-config",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -560,6 +560,11 @@
         "jsx-ast-utils": "^1.4.1"
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.4.0.tgz",
+      "integrity": "sha512-fMGlzztW/5hSQT0UBnlPwulao0uF8Kyp0Uv6PA81lzmcDz2LBtthkWQaE8Wz2F2kEe7mSRDgK8ABEFK1ipeDxw=="
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/lessonly/eslint-config-lessonly#readme",
   "peerDependencies": {
-    "eslint": ">= 5.9.0"
+    "eslint": ">= 3.19.0"
   },
   "dependencies": {
     "babel-eslint": "7.2.3",
@@ -30,7 +30,8 @@
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsx-a11y": "5.0.1",
-    "eslint-plugin-react": "7.1.0"
+    "eslint-plugin-react": "7.1.0",
+    "eslint-plugin-react-hooks": "1.4.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lessonly/eslint-config",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Lessonly's Javascript style guide",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Why?

Resolves [ch23214]

## What

This adds react-hooks rules to our eslint config, which allows us to enforce the following rules:

### Avoid using hooks conditionally, from within callbacks, loops, etc.

This will throw an error as it results in bugs.

<img width="548" alt="screen shot 2019-03-06 at 7 52 40 pm" src="https://user-images.githubusercontent.com/2100222/53924574-8e42a280-404a-11e9-9e26-4ed8403bcf8d.png">

**Example**

```
44:21  error  React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render  react-hooks/rules-of-hooks

✖ 1 problem (1 error, 0 warnings)
```

### Verify the list of deps some hooks require such as useEffect and useCallback

This makes sure that you are setting the right dependencies that ensure the callbacks are memoized properly.

**Example**

```
4:39  error  React Hook useEffect has a missing dependency: 'title'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

✖ 1 problem (1 error, 0 warning)
```

## Further Reading

https://reactjs.org/docs/hooks-rules.html

## Merging Instructions

The package-lock version was out of sync so I fixed it. I also bumped the version from `0.0.2` to `0.1.0` in this PR since it's the only piece of work I’m expecting to go out very soon on this repo.

- [ ] Once merged, this should be ready to publish to npm.
- [ ] Once published, move the CH ticket to "waiting on remediation"